### PR TITLE
Pass in bundle to validate against

### DIFF
--- a/app/models/qrda_file.rb
+++ b/app/models/qrda_file.rb
@@ -21,10 +21,10 @@ class QrdaFile
     @content
   end
 
-  def process
+  def process(bundle: nil)
     @measure_ids = get_measure_ids
 
-    @bundle = BUNDLES[program_year]
+    @bundle = bundle || BUNDLES[program_year]
 
     self.validation_errors = { qrda: [], reporting: [], submission: [], ungrouped: [] }
     validators.each do |v|


### PR DESCRIPTION
The bundles are not loaded at runtime when we use the gem for
validation. In order to use the bundle for validation we need to pass in
a bundle. We tried in the initializer where they are defined, but the
database connection is not available there so this seems like the
easiest way to accomplish this.